### PR TITLE
Update flask version to resolve conflict with a deprecated version of…

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,5 @@
-flask==1.1.2
+flask==1.1.4
 Flask-Cors==3.0.9
+# https://github.com/aws/aws-sam-cli/issues/3661
+# Resolves `ImportError: cannot import name 'soft_unicode' from 'markupsafe`
+markupsafe==2.0.1


### PR DESCRIPTION
… the itsdangerous package. Add markupsafe to the requirements file to resolve another dependency issue.

- Update Flask from 1.1.2 to 1.1.4 due to because "...the latest released (itsdangerous) version (2.10) deprecated the JSON API". Solution is to update Flask or add `itsdangerous==2.0.1` [1]

- Resolve a follow on error of `ImportError: cannot import name 'soft_unicode' from 'markupsafe` because something depends on an older version of markupsafe but the latest version of it removes the soft_unicode.

![image](https://user-images.githubusercontent.com/1485767/157756152-d91eca0a-1ef0-4e11-a334-3d8036488738.png)

But this got the Python server running!

[1] https://serverfault.com/questions/1094062/error-from-itsdangerous-import-json-as-json-importerror-cannot-import-name-j 

[2] https://github.com/aws/aws-sam-cli/issues/3661